### PR TITLE
No warmup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: '10'
   warmupSeconds:
     description: 'The number of seconds to poll until a check should be found'
-    default: '10'
+    default: '0'
 runs:
   using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Set `warmupSeconds` to 0 by default, because there's a status "queued" which will happen so in fact I think out sleeping in `health-tech/.github/workflows/Required.yml` was useless
