### PR TITLE
Implement optional cancellation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   warmupSeconds:
     description: 'The number of seconds to poll until a check/workflow should be found'
     default: '0'
+  cancelOnFailure:
+    description: If true, when the conclusion isn't any of the `successConclusions`, the current workflow is cancelled instead of failed.
+    default: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -75,13 +75,15 @@ function run() {
                 : yield (0, poll_workflow_1.pollWorkflowruns)(Object.assign(Object.assign({}, inputs), { workflowNames }));
             core.setOutput('conclusion', conclusion);
             if (!successConclusions.includes(conclusion)) {
-                if (core.getInput('cancelOnFailure') === 'true') {
-                    yield cancelCurrentWorkflow(inputs.client);
-                    core.setFailed(`Conclusion '${conclusion}' was not defined as a success`);
-                    core.info('Cancelling current workflow...');
-                    yield new Promise(res => setTimeout(res, 60000));
-                }
                 core.setFailed(`Conclusion '${conclusion}' was not defined as a success`);
+                if (core.getInput('cancelOnFailure') === 'true') {
+                    core.info('Cancelling current workflow...');
+                    yield cancelCurrentWorkflow(inputs.client);
+                    for (let index = 0; index < 60; index++) {
+                        core.debug('Waiting for current workflow to be cancelled...');
+                        yield new Promise(res => setTimeout(res, 1000));
+                    }
+                }
             }
         }
         catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -77,11 +77,9 @@ function run() {
             if (!successConclusions.includes(conclusion)) {
                 if (core.getInput('cancelOnFailure') === 'true') {
                     yield cancelCurrentWorkflow(inputs.client);
-                    core.info('Waiting for workflow to be cancelled...');
-                    for (let index = 0; index < 60; index++) {
-                        core.info('Waiting for workflow to be cancelled...');
-                        yield new Promise(res => setTimeout(res, 1000));
-                    }
+                    core.setFailed(`Conclusion '${conclusion}' was not defined as a success`);
+                    core.info('Cancelling current workflow...');
+                    yield new Promise(res => setTimeout(res, 60000));
                 }
                 core.setFailed(`Conclusion '${conclusion}' was not defined as a success`);
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,10 @@ async function run(): Promise<void> {
         await cancelCurrentWorkflow(inputs.client)
           
         core.info('Waiting for workflow to be cancelled...')
-        await new Promise(res => setTimeout(res, 60_000))
+        for (let index = 0; index < 60; index++) {
+          core.info('Waiting for workflow to be cancelled...')
+          await new Promise(res => setTimeout(res, 1_000))
+        }
       }
       
       core.setFailed(`Conclusion '${conclusion}' was not defined as a success`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,19 @@ async function run(): Promise<void> {
     core.setOutput('conclusion', conclusion)
     if (!successConclusions.includes(conclusion)) {
       core.setFailed(`Conclusion '${conclusion}' was not defined as a success`)
+
+      if (core.getInput('cancelOnFailure') === 'true') {
+        inputs.client.rest.actions.cancelWorkflowRun({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          run_id: context.runId
+        })
+          
+        core.info('Waiting for workflow to be cancelled...')
+        while (true) {
+          await new Promise(res => setTimeout(res, 10000))
+        }
+      }
     }
   } catch (error) {
     core.setFailed(error instanceof Error ? error : JSON.stringify(error))

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,11 +45,9 @@ async function run(): Promise<void> {
       if (core.getInput('cancelOnFailure') === 'true') {
         await cancelCurrentWorkflow(inputs.client)
 
-        core.info('Waiting for workflow to be cancelled...')
-        for (let index = 0; index < 60; index++) {
-          core.info('Waiting for workflow to be cancelled...')
-          await new Promise(res => setTimeout(res, 1_000))
-        }
+        core.setFailed(`Conclusion '${conclusion}' was not defined as a success`)
+        core.info('Cancelling current workflow...')
+        await new Promise(res => setTimeout(res, 60_000))
       }
 
       core.setFailed(`Conclusion '${conclusion}' was not defined as a success`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,14 +44,14 @@ async function run(): Promise<void> {
     if (!successConclusions.includes(conclusion)) {
       if (core.getInput('cancelOnFailure') === 'true') {
         await cancelCurrentWorkflow(inputs.client)
-          
+
         core.info('Waiting for workflow to be cancelled...')
         for (let index = 0; index < 60; index++) {
           core.info('Waiting for workflow to be cancelled...')
           await new Promise(res => setTimeout(res, 1_000))
         }
       }
-      
+
       core.setFailed(`Conclusion '${conclusion}' was not defined as a success`)
     }
   } catch (error) {
@@ -73,11 +73,11 @@ function areCheckNameAndWorkflowNameValid(checkName: string, workflowName: strin
   return true
 }
 
-function cancelCurrentWorkflow(client: InstanceType<typeof GitHub>) {
-  return client.rest.actions.cancelWorkflowRun({
+async function cancelCurrentWorkflow(client: InstanceType<typeof GitHub>): Promise<unknown> {
+  return await client.rest.actions.cancelWorkflowRun({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    run_id: context.runId
+    run_id: context.runId,
   })
 }
 run()


### PR DESCRIPTION
Currently in surgery-planning, when on a merge a screenshot test fails, all matrix runs of `push.yaml` also fail, which can seem a bit daunting. lots of errors, and moreover they are hiding the original error.

If I make it a cancellation, it seems less daunting