### PR TITLE
Warn instead of fail on failed workflow cancellation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-wait-for-check",
-  "version": "1.1.0",
+  "version": "3.1.1",
   "private": true,
   "description": "A GitHub action that waits for other GitHub checks to complete",
   "main": "lib/main.js",


### PR DESCRIPTION
I've seen that the cancellating request fails.
In that case we should probably retry and otherwise just ignore/warn. No need to error then, that sort of defaults the purpose of cancelling (which is to prevent the :x:)