### PR TITLE
Allow for `anyOf` multiple check-runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./
-        id: wait-for-build
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: build
           successConclusions: success
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Also do an integration test run with anyOf(...)
+        uses: ./
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: build
+          successConclusions: anyOf(success)
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   ensure-npm-ran-pack: # make sure the js is compiled

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This Action accepts the following configuration parameters via `with:`
 
   **Required if no `workflowName` is specified.**
   
-  The name of the GitHub check to wait for. For example, `build` or `deploy`.
+  The name(s) of the GitHub check(s) to wait for. For example, `build` or `deploy`. If providing multiple, separate by newline.
 
   **IMPORTANT**: If the check you're referencing is provided by another GitHub Actions workflow, make sure that you reference the name of a _job_ within that workflow, and _not_ the name the _workflow_ itself. If you want to wait for a workflow, i.e. all jobs within it, specify a `workflowName`.
   

--- a/__tests__/poll.check.test.ts
+++ b/__tests__/poll.check.test.ts
@@ -205,3 +205,60 @@ test('reflects the status of the last started run', async () => {
 
   expect(result).toBe('failure')
 })
+
+test('can handle multiple check names', async () => {
+  client.rest.checks.listForRef
+    .mockResolvedValueOnce({
+      // t = 0, checkrun = 0
+      data: {
+        check_runs: [
+          {
+            id: '1',
+            status: 'in_progress',
+            started_at: '2018-01-01T00:00:01Z',
+          },
+        ],
+      },
+    })
+    .mockResolvedValueOnce({
+      // t = 0, checkrun = 1
+      data: {
+        check_runs: [
+          {
+            id: '2',
+            status: 'in_progress',
+            started_at: '2018-01-01T00:00:01Z',
+          },
+        ],
+      },
+    })
+    .mockResolvedValueOnce({
+      // t = 1, checkrun = 0
+      data: {
+        check_runs: [
+          {
+            id: '1',
+            status: 'in_progress',
+            started_at: '2018-01-01T00:00:01Z',
+          },
+        ],
+      },
+    })
+    .mockResolvedValueOnce({
+      // t = 1, checkrun = 1
+      data: {
+        check_runs: [
+          {
+            id: '2',
+            status: 'completed',
+            conclusion: 'failure',
+            started_at: '2018-01-01T00:00:01Z',
+          },
+        ],
+      },
+    })
+
+  const result = await run()
+
+  expect(result).toBe('failure')
+})

--- a/__tests__/poll.check.test.ts
+++ b/__tests__/poll.check.test.ts
@@ -262,3 +262,49 @@ test('can handle multiple check names', async () => {
 
   expect(result).toBe('failure')
 })
+
+test('awaiting multiple checks of which one succeeded and one is pending does not result in succeeded', async () => {
+  client.rest.checks.listForRef
+    .mockResolvedValueOnce({
+      // t = 0, checkrun = 0
+      data: {
+        check_runs: [
+          {
+            id: '1',
+            status: 'completed',
+            conclusion: 'success',
+            started_at: '2018-01-01T00:00:01Z',
+          },
+        ],
+      },
+    })
+    .mockResolvedValueOnce({
+      // t = 0, checkrun = 1
+      data: {
+        check_runs: [
+          {
+            id: '2',
+            status: 'in_progress',
+            started_at: '2018-01-01T00:00:01Z',
+          },
+        ],
+      },
+    })
+    .mockResolvedValueOnce({
+      // t = 1, checkrun = 1
+      data: {
+        check_runs: [
+          {
+            id: '2',
+            status: 'completed',
+            conclusion: 'failure',
+            started_at: '2018-01-01T00:00:01Z',
+          },
+        ],
+      },
+    })
+
+  const result = await run()
+
+  expect(result).toBe('failure')
+})

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,13 @@ inputs:
     description: 'The GitHub token to use for making API requests.'
     required: true
   checkName:
-    description: 'The name of the GitHub check/workflow to wait for. For example, `build` or `deploy`. Either this xor "workflowName" must be provided.'
+    description: |
+      The name of the GitHub check/workflow to wait for. For example, `build` or `deploy`. Either this xor "workflowName" must be provided.
+      It can also be a list of check names, in the form of a newline-separated list.
   workflowName:
     description: |
        The name of the GitHub workflow to wait for. For example, `build` or `deploy`. Either this xor "checkName" must be provided.
-       It can also be a list of workflow names, in the for of a newline-separated list, or comma-separated list between square brackets.
+       It can also be a list of workflow names, in the form of a newline-separated list or comma-separated list between square brackets.
   ref:
     description: |
       The Git ref of the commit you want to poll for a passing check/workflow.

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,10 @@ inputs:
     description: |
       A list of conlusions of the check/workflow run that will result in this action run succeeding.
       Possible options are: 
-          success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found
+          success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found optionally wrapped by `anyOf(...)`
+
+      If wrapped by `anyOf(...)`, then if any check of workflow conclusion matches any of the provided options, `success` is concluded.
+      If not wrapped, then all check or workflow conclusions must match the provided options to conclude.
     default: "success|skipped|not_found"
   repo:
     description: 'The name of the GitHub repository you want to poll for a passing check/workflow.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -458,6 +458,7 @@ function maxBy(array, selector) {
 exports.maxBy = maxBy;
 function parseSuccessConclusions(successConclusions, core) {
     let any = false;
+    successConclusions = successConclusions.trim();
     if (successConclusions.startsWith('anyOf(')) {
         if (!successConclusions.endsWith(')')) {
             core.setFailed("Invalid 'successConclusions'. If starting with 'anyOf(' it must end on a ')'");

--- a/dist/index.js
+++ b/dist/index.js
@@ -465,7 +465,9 @@ function parseSuccessConclusions(successConclusions, core) {
             return undefined;
         }
         any = true;
+        core.debug('Trimming "anyOf(" and ")"');
         successConclusions = successConclusions.substring('anyOf('.length, successConclusions.length - 1 - ')'.length);
+        core.debug(`successConclusions=${successConclusions}`);
     }
     const regex = /^(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found)(\|(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found))*$/;
     if (!regex.test(successConclusions)) {
@@ -474,6 +476,7 @@ function parseSuccessConclusions(successConclusions, core) {
     }
     const result = successConclusions.split('|');
     if (any) {
+        core.debug('Pushing "any"');
         result.push('any');
     }
     core.debug(`successConclusions.split('|'): ${JSON.stringify(result)}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -149,25 +149,31 @@ const poll_1 = __nccwpck_require__(5498);
 class CheckPoller {
     func(options) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { client, log, checkName, intervalSeconds, owner, repo, ref } = options;
-            log(`Retrieving check runs named '${checkName}' on ${owner}/${repo}@${ref}...`);
-            const result = yield client.rest.checks.listForRef({
-                check_name: checkName,
-                owner,
-                repo,
-                ref,
-            });
-            log(`Retrieved ${result.data.check_runs.length} check runs named '${checkName}'`);
-            const lastStartedCheck = this.getLastStartedCheck(result.data.check_runs);
-            if (lastStartedCheck !== undefined && lastStartedCheck.status === 'completed') {
-                log(`Found a completed check with id ${lastStartedCheck.id} and conclusion '${lastStartedCheck.conclusion}'`);
-                // conclusion is only `null` if status is not `completed`.
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                return lastStartedCheck.conclusion;
+            const { client, log, checkNames, intervalSeconds, owner, repo, ref } = options;
+            let hasLastStartedCheck = false;
+            for (const checkName of checkNames) {
+                log(`Retrieving check runs named '${checkName}' on ${owner}/${repo}@${ref}...`);
+                const result = yield client.rest.checks.listForRef({
+                    check_name: checkName,
+                    owner,
+                    repo,
+                    ref,
+                });
+                log(`Retrieved ${result.data.check_runs.length} check runs named '${checkName}'`);
+                const lastStartedCheck = this.getLastStartedCheck(result.data.check_runs);
+                if (lastStartedCheck !== undefined) {
+                    if (lastStartedCheck.status === 'completed') {
+                        log(`Found a completed check with id ${lastStartedCheck.id} and conclusion '${lastStartedCheck.conclusion}'`);
+                        // conclusion is only `null` if status is not `completed`.
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        return lastStartedCheck.conclusion;
+                    }
+                    hasLastStartedCheck = true;
+                }
             }
-            log(`No completed checks named '${checkName}', waiting for ${intervalSeconds} seconds...`);
+            log(`No completed checks named '${checkNames.join("', '")}', waiting for ${intervalSeconds} seconds...`);
             log('');
-            return lastStartedCheck === undefined ? undefined : null;
+            return hasLastStartedCheck ? null : undefined;
         });
     }
     onTimedOut(options, warmupDeadlined) {
@@ -193,7 +199,9 @@ class CheckPoller {
 }
 function pollCheckrun(options) {
     return __awaiter(this, void 0, void 0, function* () {
-        return yield (0, poll_1.poll)(options, new CheckPoller());
+        const checkNames = options.checkName.split('\n').map(name => name.trim());
+        options.log(`Check names: '${checkNames.join("', '")}'`);
+        return yield (0, poll_1.poll)(Object.assign(Object.assign({}, options), { checkNames }), new CheckPoller());
     });
 }
 exports.pollCheckrun = pollCheckrun;

--- a/dist/index.js
+++ b/dist/index.js
@@ -466,7 +466,7 @@ function parseSuccessConclusions(successConclusions, core) {
         }
         any = true;
         core.debug('Trimming "anyOf(" and ")"');
-        successConclusions = successConclusions.substring('anyOf('.length, successConclusions.length - 1 - ')'.length);
+        successConclusions = successConclusions.substring('anyOf('.length, successConclusions.length - ')'.length);
         core.debug(`successConclusions=${successConclusions}`);
     }
     const regex = /^(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found)(\|(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found))*$/;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-wait-for-check",
-  "version": "3.1.1",
+  "version": "3.2",
   "private": true,
   "description": "A GitHub action that waits for other GitHub checks to complete",
   "main": "lib/main.js",

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,7 +15,7 @@ export interface SharedOptions {
 }
 
 export interface CheckOptions extends SharedOptions {
-  checkName: string
+  checkNames: string[]
 }
 
 export interface WorkflowOptions extends SharedOptions {

--- a/src/poll.check.ts
+++ b/src/poll.check.ts
@@ -21,11 +21,10 @@ class CheckPoller implements Poller<Options> {
 
       const lastStartedCheck = this.getLastStartedCheck(result.data.check_runs)
       if (lastStartedCheck !== undefined) {
-        if (lastStartedCheck.status === 'completed') {
+        if (isCompleted(lastStartedCheck)) {
           log(`Found a completed check with id ${lastStartedCheck.id} and conclusion '${lastStartedCheck.conclusion}'`)
-          // conclusion is only `null` if status is not `completed`.
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return lastStartedCheck.conclusion!
+
+          return lastStartedCheck.conclusion
         }
         hasLastStartedCheck = true
       }
@@ -57,6 +56,10 @@ class CheckPoller implements Poller<Options> {
   }
 }
 
+function isCompleted(checkRun: CheckRun): checkRun is CheckRun & {conclusion: Exclude<CheckRun['conclusion'], null>} {
+  // conclusion is only `null` if status is not `completed`.
+  return checkRun.status === 'completed'
+}
 export async function pollCheckrun(options: Omit<Options, 'checkNames'> & {checkName: string}): Promise<Conclusion> {
   const checkNames = options.checkName.split('\n').map(name => name.trim())
   options.log(`Check names: '${checkNames.join("', '")}'`)

--- a/src/poll.workflow.ts
+++ b/src/poll.workflow.ts
@@ -78,6 +78,9 @@ export async function pollWorkflowruns(options: WorkflowsOptions): Promise<Concl
     options.log(`[Workflow ${i}/${options.workflowNames.length}] ---------------------`)
 
     const conclusion = await pollWorkflowrun({...options, workflowName})
+    if (options.successConclusions.includes('any') && options.successConclusions.includes(conclusion)) {
+      return 'success'
+    }
     if (!options.successConclusions.includes(conclusion)) {
       // TODO: we could be smart and in case of a not_found revisit that workflow later
       // As workaround the workflowNames can be provided in execution order

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,6 +65,15 @@ export function maxBy<T>(array: T[], selector: (element: T) => number): T {
 }
 
 export function parseSuccessConclusions(successConclusions: string, core: typeof actionsCore): string[] | undefined {
+  let any = false
+  if (successConclusions.startsWith('anyOf(')) {
+    if (!successConclusions.endsWith(')')) {
+      core.setFailed("Invalid 'successConclusions'. If starting with 'anyOf(' it must end on a ')'")
+      return undefined
+    }
+    any = true
+    successConclusions = successConclusions.substring('anyOf('.length, successConclusions.length - 1 - ')'.length)
+  }
   const regex =
     /^(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found)(\|(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found))*$/
   if (!regex.test(successConclusions)) {
@@ -74,6 +83,9 @@ export function parseSuccessConclusions(successConclusions: string, core: typeof
     return undefined
   }
   const result = successConclusions.split('|')
+  if (any) {
+    result.push('any')
+  }
   core.debug(`successConclusions.split('|'): ${JSON.stringify(result)}`)
   return result
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,6 +66,7 @@ export function maxBy<T>(array: T[], selector: (element: T) => number): T {
 
 export function parseSuccessConclusions(successConclusions: string, core: typeof actionsCore): string[] | undefined {
   let any = false
+  successConclusions = successConclusions.trim()
   if (successConclusions.startsWith('anyOf(')) {
     if (!successConclusions.endsWith(')')) {
       core.setFailed("Invalid 'successConclusions'. If starting with 'anyOf(' it must end on a ')'")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,7 +74,7 @@ export function parseSuccessConclusions(successConclusions: string, core: typeof
     }
     any = true
     core.debug('Trimming "anyOf(" and ")"')
-    successConclusions = successConclusions.substring('anyOf('.length, successConclusions.length - 1 - ')'.length)
+    successConclusions = successConclusions.substring('anyOf('.length, successConclusions.length - ')'.length)
     core.debug(`successConclusions=${successConclusions}`)
   }
   const regex =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,9 @@ export function parseSuccessConclusions(successConclusions: string, core: typeof
       return undefined
     }
     any = true
+    core.debug('Trimming "anyOf(" and ")"')
     successConclusions = successConclusions.substring('anyOf('.length, successConclusions.length - 1 - ')'.length)
+    core.debug(`successConclusions=${successConclusions}`)
   }
   const regex =
     /^(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found)(\|(success|failure|neutral|cancelled|skipped|timed_out|action_required|not_found))*$/
@@ -85,6 +87,7 @@ export function parseSuccessConclusions(successConclusions: string, core: typeof
   }
   const result = successConclusions.split('|')
   if (any) {
+    core.debug('Pushing "any"')
     result.push('any')
   }
   core.debug(`successConclusions.split('|'): ${JSON.stringify(result)}`)


### PR DESCRIPTION
Allows the `checkName` input to take multiple names, checking for whether _any of_ or _all or_ those succeeded